### PR TITLE
add version 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:lts-alpine3.16
 
 COPY package.json ./
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ env:
 jobs:
   BuildClusterAnsible:
     - name: Create filenames
-      uses: smu-chile/gh-action-consul-to-env-file@v1.0.1
+      uses: smu-chile/gh-action-consul-to-env-file@v1.0.2
       with:
         consul_address: ""
         consul_token: ${{ secrets.CONSUL_HTTP_TOKEN }}


### PR DESCRIPTION
## What problem is this solving?
    Ansible execution fails because consul variable read step is not enabled

## Types of changes

- [X] Add version node:lts-alpine3.16 by node:lts-alpine

## Additional Info

- [(https://github.com/smu-chile/terraform-gcp-gke-alvipagos/actions/runs/6395778356/job/18063840490)](https://github.com/smu-chile/ms-debit-credit-mdw/actions/runs/6656682276/job/18090079366)

## Checklist


- [X] Breaking change (fix or feature that would cause existing functionality to change)


## Screenshots

- 
![Screenshot 2023-10-26 at 11 13 32 AM](https://github.com/smu-chile/gh-action-consul-to-env-file/assets/83984980/66026245-6825-436b-bd52-714397312ad2)

